### PR TITLE
fix(gmail): use custom http.Client in gmail service

### DIFF
--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -36,7 +36,10 @@ func (c *Client) Send(ctx context.Context, token *oauth2.Token, rawEmail []byte)
 	c.logger.Info("sending email via gmail api")
 
 	// Create a new Gmail service using the provided token
-	srv, err := gmail.NewService(ctx, option.WithTokenSource(oauth2.StaticTokenSource(token)))
+	srv, err := gmail.NewService(ctx,
+		option.WithHTTPClient(c.client),
+		option.WithTokenSource(oauth2.StaticTokenSource(token)),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gmail service: %w", err)
 	}


### PR DESCRIPTION
The `New` function in `internal/gmail/client.go` accepts and stores a custom `*http.Client`, but the `Send` method did not use it when creating the `gmail.Service`.

This meant any custom transport configurations (like proxies, specific TLS settings, or mock servers for testing) were ignored.

This change passes the stored `http.Client` to `gmail.NewService` using `option.WithHTTPClient`, ensuring the custom client is used for all API requests made by the service.